### PR TITLE
fix: :arrow_up: Fix installing issue with pip install .

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,22 @@
 [build-system]
 requires = [
-    "lxml",
-    "html2text",
-    "pydantic",
-    "babel",
-    "xlsxwriter",
-    "pandas"
+    "setuptools",
 ]
 build-backend = "setuptools.build_meta"
+[tool.setuptools.packages.find]
+exclude = ["locales"]
+[project]
+name = "TRICC"
+version = "1.0.1"
+description = "Python library that converts XLS to Fhir SDC ressource."
+dependencies = [
+    "wheel",
+    "lxml",
+    "html2text",
+    "pydantic == 1.*",
+    "babel",
+    "xlsxwriter",
+    "polib",
+    "numpy",
+    "pandas"
+]


### PR DESCRIPTION
The current toml file does not install dependencies correctly. This modified toml file will install dependencies with the normal pip install command. 